### PR TITLE
makefile needs tab indent

### DIFF
--- a/.make.mk
+++ b/.make.mk
@@ -13,28 +13,28 @@ build: ## Build necessary Docker image for building packages
   @docker image build -t phpearth-abuild:$(version) -f .docker/abuild/Dockerfile .docker/abuild
 
 run: ## Run a command in a new Docker container; make run a=[...]
-  make build
+  $(MAKE) build
   @docker container run -it --rm -v `pwd`/packages:/$(version)/ -v `pwd`/public:/public phpearth-abuild:$(version) $(a)
 
 package: ## Usage: make package [p="7.1|7.2|7.3|all|<package-name1> <package-name2> ..."]
   @test "$(p)"
-  make run a="package -p \"$(p)\""
+  $(MAKE) run a="package -p \"$(p)\""
 
 generate-index: ## Generate index file APKINDEX.tar.gz usage: make generate-index
-  make run a="generate-index"
+  $(MAKE) run a="generate-index"
 
 private-key: ## Generate new private key
-  make run a="openssl genrsa -out phpearth.rsa.priv 4096 --build --force-recreate"
+  $(MAKE) run a="openssl genrsa -out phpearth.rsa.priv 4096 --build --force-recreate"
   mv packages/phpearth.rsa.priv .docker/abuild/home/packager/.abuild/
 
 public-key: ## Generate new public key
-  make run a="openssl rsa -in /home/packager/.abuild/phpearth.rsa.priv -pubout -out /public/phpearth.rsa.pub"
+  $(MAKE) run a="openssl rsa -in /home/packager/.abuild/phpearth.rsa.priv -pubout -out /public/phpearth.rsa.pub"
 
 clean: ## Remove pkg, src, and tmp folders when building packages for Alpine
   @rm -rf packages/*/pkg packages/*/src packages/*/tmp
 
 sh: ## Run shell
-  make run a=sh
+  $(MAKE) run a=sh
 
 upload: ## Upload build packages to Linux repos server
   @rsync -avz --del public/$(version)/ repos.php.earth:~/repos/alpine/$(version)/

--- a/.make.mk
+++ b/.make.mk
@@ -1,0 +1,40 @@
+.RECIPEPREFIX +=
+.DEFAULT_GOAL := help
+.PHONY: *
+
+# Alpine distribution verion
+version = v3.9
+
+help:
+  @echo "\033[33mUsage:\033[0m\n  make [target] [arg=\"val\"...]\n\n\033[33mTargets:\033[0m"
+  @grep -hE '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[32m%-15s\033[0m %s\n", $$1, $$2}'
+
+build: ## Build necessary Docker image for building packages
+  @docker image build -t phpearth-abuild:$(version) -f .docker/abuild/Dockerfile .docker/abuild
+
+run: ## Run a command in a new Docker container; make run a=[...]
+  make build
+  @docker container run -it --rm -v `pwd`/packages:/$(version)/ -v `pwd`/public:/public phpearth-abuild:$(version) $(a)
+
+package: ## Usage: make package [p="7.1|7.2|7.3|all|<package-name1> <package-name2> ..."]
+  @test "$(p)"
+  make run a="package -p \"$(p)\""
+
+generate-index: ## Generate index file APKINDEX.tar.gz usage: make generate-index
+  make run a="generate-index"
+
+private-key: ## Generate new private key
+  make run a="openssl genrsa -out phpearth.rsa.priv 4096 --build --force-recreate"
+  mv packages/phpearth.rsa.priv .docker/abuild/home/packager/.abuild/
+
+public-key: ## Generate new public key
+  make run a="openssl rsa -in /home/packager/.abuild/phpearth.rsa.priv -pubout -out /public/phpearth.rsa.pub"
+
+clean: ## Remove pkg, src, and tmp folders when building packages for Alpine
+  @rm -rf packages/*/pkg packages/*/src packages/*/tmp
+
+sh: ## Run shell
+  make run a=sh
+
+upload: ## Upload build packages to Linux repos server
+  @rsync -avz --del public/$(version)/ repos.php.earth:~/repos/alpine/$(version)/

--- a/Makefile
+++ b/Makefile
@@ -1,40 +1,9 @@
-.RECIPEPREFIX +=
-.DEFAULT_GOAL := help
-.PHONY: *
+MAKE_VERSION_MAJOR := $(shell $(MAKE) -version | sed -ne 's/^GNU Make \([0-9]\).*/\1/p')
 
-# Alpine distribution verion
-version = v3.9
-
-help:
-  @echo "\033[33mUsage:\033[0m\n  make [target] [arg=\"val\"...]\n\n\033[33mTargets:\033[0m"
-  @grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[32m%-15s\033[0m %s\n", $$1, $$2}'
-
-build: ## Build necessary Docker image for building packages
-  @docker image build -t phpearth-abuild:$(version) -f .docker/abuild/Dockerfile .docker/abuild
-
-run: ## Run a command in a new Docker container; make run a=[...]
-  make build
-  @docker container run -it --rm -v `pwd`/packages:/$(version)/ -v `pwd`/public:/public phpearth-abuild:$(version) $(a)
-
-package: ## Usage: make package [p="7.1|7.2|7.3|all|<package-name1> <package-name2> ..."]
-  @test "$(p)"
-  make run a="package -p \"$(p)\""
-
-generate-index: ## Generate index file APKINDEX.tar.gz usage: make generate-index
-  make run a="generate-index"
-
-private-key: ## Generate new private key
-  make run a="openssl genrsa -out phpearth.rsa.priv 4096 --build --force-recreate"
-  mv packages/phpearth.rsa.priv .docker/abuild/home/packager/.abuild/
-
-public-key: ## Generate new public key
-  make run a="openssl rsa -in /home/packager/.abuild/phpearth.rsa.priv -pubout -out /public/phpearth.rsa.pub"
-
-clean: ## Remove pkg, src, and tmp folders when building packages for Alpine
-  @rm -rf packages/*/pkg packages/*/src packages/*/tmp
-
-sh: ## Run shell
-  make run a=sh
-
-upload: ## Upload build packages to Linux repos server
-  @rsync -avz --del public/$(version)/ repos.php.earth:~/repos/alpine/$(version)/
+ifeq ($(shell test $(MAKE_VERSION_MAJOR) -lt 4; echo $$?),0)
+unsupported-make:
+	@echo "This version of make is unsupported, GNU Make >= 4 is needed"
+	@echo "For macOS install brew install make"
+else
+	include .make.mk
+endif


### PR DESCRIPTION
to be portable, for example make 3.81, shipped with macOS 10.14.4 is broken with spaces.

more reading:
- https://superuser.com/questions/224434/what-is-the-character-used-to-indent-the-make-file-rule-recipe
- https://stackoverflow.com/questions/2131213/can-you-make-valid-makefiles-without-tab-characters
- https://www.gnu.org/software/make/manual/html_node/Special-Variables.html