### PR TITLE
generate-index: skip force arch

### DIFF
--- a/.docker/abuild/usr/local/bin/generate-index
+++ b/.docker/abuild/usr/local/bin/generate-index
@@ -13,7 +13,7 @@ if test -z "$ALPINE_VERSION"; then
 fi
 
 cd /public/$ALPINE_VERSION/x86_64
-apk index -o APKINDEX.unsigned.tar.gz *.apk --rewrite-arch x86_64
+apk index -o APKINDEX.unsigned.tar.gz *.apk
 openssl dgst -sha1 -sign /home/packager/.abuild/phpearth.rsa.priv -out .SIGN.RSA.phpearth.rsa.pub APKINDEX.unsigned.tar.gz
 tar -c .SIGN.RSA.phpearth.rsa.pub | abuild-tar --cut | gzip -9 > signature.tar.gz
 cat signature.tar.gz APKINDEX.unsigned.tar.gz > APKINDEX.tar.gz


### PR DESCRIPTION
why the force index? does not seem necessary, and kills `noarch` packages.

the force was added with the initial commit bdd0a5fae9a6af5050f7a6088c9bb8f6ef0accd3

the tree in that repo before the split seems to be https://github.com/phpearth/docker-php/commit/52839dd899f9166a780413a23b2669203aecb4e7